### PR TITLE
Set TEMPLATE_ENV_WHITELIST

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -3,6 +3,6 @@
 ## Copyright (C) 2012 - 2014 Patrick Schleizer <adrelanos@riseup.net>
 ## See the file COPYING for copying conditions.
 
-## Empty Makefile.builder to prevent Qubes Builder from trying to build this
-## and failing.
-## https://phabricator.whonix.org/T407
+# Environment variables (set in builder.conf) that should be made available to
+# template build scripts
+TEMPLATE_ENV_WHITELIST += WHONIX_APT_REPOSITORY_OPTS WHONIX_ENABLE_TOR WHONIX_DIR


### PR DESCRIPTION
Since recently, template build environment is filtered from unwanted
variables. If something additionally is needed there, needs to be
whitelisted. This whitelist is based on what is set in builder.conf
here.
See qubes-builder/doc/BuilderPluginAPI.md for details.